### PR TITLE
XTA-1: Only allow specific files for workflow fire.

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2,8 +2,10 @@ name: Create Release
 
 on:
   push:
-    branches:
-      - master
+    paths:
+      - "src/**"
+      - ".github/workflows/**"
+      - "xmake.lua"
 
 jobs:
   bundle-windows:


### PR DESCRIPTION
Only allow files in src/**, .github/workflows/** and xmake.lua to fire
the create_release workflow